### PR TITLE
Added loging glm vectors, matrix and quaternios

### DIFF
--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -25,6 +25,25 @@ namespace Hazel {
 
 }
 
+template<typename OStream, glm::length_t L, typename T, glm::qualifier Q>
+inline OStream& operator<<(OStream& os, const glm::vec<L, T, Q>& vector)
+{
+	return os << glm::to_string(vector);
+}
+
+template<typename OStream, glm::length_t C, glm::length_t R, typename T, glm::qualifier Q>
+inline OStream& operator<<(OStream& os, const glm::mat<C, R, T, Q>& matrix)
+{
+	return os << glm::to_string(matrix);
+}
+
+template<typename OStream, typename T, glm::qualifier Q>
+inline OStream& operator<<(OStream& os, glm::qua<T, Q> quaternio)
+{
+	os << glm::to_string(quaternio);
+	return os;
+}
+
 // Core log macros
 #define HZ_CORE_TRACE(...)    ::Hazel::Log::GetCoreLogger()->trace(__VA_ARGS__)
 #define HZ_CORE_INFO(...)     ::Hazel::Log::GetCoreLogger()->info(__VA_ARGS__)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Before if you want log a glm vector, matrix or quaternio, you need type HAZEL_INFO(glm::to_string(some_vector)) and that glm::to_string is very annoying. So, now you can type HAZEL_INFO(some_vector) with out that glm::to_string.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
no more HAZEL_INFO(glm::to_string(some_vector))
